### PR TITLE
Add disk space cleanup steps in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,13 @@ jobs:
       matrix:
         target: [ "pi0", "pi2", "pi02w", "pi4" ]
     steps:
+      - name: free up additional disk space
+        run: |
+          # remove android tools, this can free up 10+ GB of space
+          sudo rm -rf /usr/local/lib/android
+          # remove all .NET SDKs, this can free up a few GB of space
+          sudo rm -rf /usr/share/dotnet
+    
       - name: checkout seedsigner-os
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Added steps to free up additional disk space by removing Android tools and .NET SDKs.

## Description

_Describe the change simply. Provide a reason for the change._

_Include screenshots of any new or modified screens (or at least explain why they were omitted)_

This pull request is categorized as a:

- [ ] New feature
- [ ] Bug fix
- [ ] Code refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [ ] I’ve run `pytest` and made sure all unit tests pass before submitting the PR

If you modified or added functionality/workflow, did you add new unit tests?

- [ ] No, I’m a fool
- [ ] Yes
- [ ] N/A

I have tested this PR on the following platforms/os:

- [ ] Raspberry Pi OS [Manual Build](https://github.com/SeedSigner/seedsigner/blob/dev/docs/manual_installation.md)
- [ ] [SeedSigner OS](https://github.com/SeedSigner/seedsigner-os) on a Pi0/Pi0W board
- [ ] Other


Note: Keep your changes limited in scope; if you uncover other issues or improvements along the way, ideally submit those as a separate PR. The more complicated the PR the harder to review, test, and merge.
